### PR TITLE
Update .env-example

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -5,7 +5,7 @@ APP_URL=https://nylo.dev
 
 API_BASE_URL=https://your-api.com
 
-ASSET_PATH_PUBLIC=public/assets/
+ASSET_PATH_PUBLIC=public/assets
 ASSET_PATH_IMAGES=public/assets/images
 TIMEZONE=UTC
 DEFAULT_LOCALE=en


### PR DESCRIPTION
Fixed env-example ASSET_PATH_PUBLIC. No trailing slash is needed