### PR TITLE
change in route name style

### DIFF
--- a/lib/resources/pages/home_page.dart
+++ b/lib/resources/pages/home_page.dart
@@ -10,9 +10,6 @@ import 'package:nylo_framework/theme/helper/ny_theme.dart';
 class HomePage extends NyStatefulWidget {
   @override
   final HomeController controller = HomeController();
-
-  static const path = '/home-page';
-
   HomePage({Key? key}) : super(key: key);
 
   @override
@@ -25,7 +22,7 @@ class _HomePageState extends NyState<HomePage> {
   @override
   init() async {
     super.init();
-
+    
   }
 
   @override

--- a/lib/routes/guards/auth_route_guard.dart
+++ b/lib/routes/guards/auth_route_guard.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_app/resources/pages/home_page.dart';
 import 'package:nylo_framework/nylo_framework.dart';
+import '../router.dart';
 
 /*
 |--------------------------------------------------------------------------
@@ -21,6 +21,6 @@ class AuthRouteGuard extends NyRouteGuard {
 
   @override
   redirectTo(BuildContext? context, NyArgument? data) async {
-    await routeTo(HomePage.path);
+    await routeTo(App.home);
   }
 }

--- a/lib/routes/router.dart
+++ b/lib/routes/router.dart
@@ -12,10 +12,14 @@ import 'package:nylo_framework/nylo_framework.dart';
 |--------------------------------------------------------------------------
 */
 
+class App {
+  static const String home = '/home-page';
+}
+
 appRouter() => nyRoutes((router) {
-  router.route(HomePage.path, (context) => HomePage(), initialRoute: true);
-  // Add your routes here
+      router.route(App.home, (context) => HomePage(), initialRoute: true);
+      // Add your routes here
 
-  // router.route(NewPage.path, (context) => NewPage(), transition: PageTransitionType.fade);
+      // router.route(NewPage.path, (context) => NewPage(), transition: PageTransitionType.fade);
 
-});
+    });


### PR DESCRIPTION
I have seen the route style and name. like HomePage gave path = '/home-page' and try developing faster than first finding pages and then finding route it challenging to find route name then the solution is named route give in the main file router.dart then easily defines route and use of route only one class defines all routes, easy naming, and some time for changing route names. Going to every page file and changing route names is also a problem.


Now is like this 
```
appRouter() => nyRoutes((router) {
  router.route(HomePage.path, (context) => HomePage(), initialRoute: true);
  // Add your routes here

  // router.route(NewPage.path, (context) => NewPage(), transition: PageTransitionType.fade);

});
```

Changing this better code and making it easy to use
```
class App {
  static const String home = '/home-page';
}

appRouter() => nyRoutes((router) {
      router.route(App.home, (context) => HomePage(), initialRoute: true);
});

```

Also tell me I have a change in this code given to me and guide me on this project to motivate me to contribute code.