### PR TITLE
Enable Flutter Linter

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,30 +1,28 @@
-# This file configures the static analysis results for your project (errors,
-# warnings, and lints).
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
 #
-# This enables the 'recommended' set of lints from `package:lints`.
-# This set helps identify many issues that may lead to problems when running
-# or consuming Dart code, and enforces writing Dart using a single, idiomatic
-# style and format.
-#
-# If you want a smaller set of lints you can change this to specify
-# 'package:lints/core.yaml'. These are just the most critical lints
-# (the recommended set includes the core lints).
-# The core lints are also what is used by pub.dev for scoring packages.
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
 
-#include: package:lints/recommended.yaml
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
 
-# Uncomment the following section to specify additional rules.
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at https://dart.dev/lints.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
-# linter:
-#   rules:
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
-
-# For more information about the core and recommended set of lints, see
-# https://dart.dev/go/core-lints
-
-# For additional information about configuring this file, see
+# Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/app/controllers/home_controller.dart
+++ b/lib/app/controllers/home_controller.dart
@@ -5,10 +5,6 @@ import 'package:url_launcher/url_launcher.dart';
 import 'controller.dart';
 
 class HomeController extends Controller {
-  @override
-  construct(BuildContext context) {
-    super.construct(context);
-  }
 
   onTapDocumentation() async {
     await launchUrl(Uri.parse("https://nylo.dev/docs"));
@@ -31,7 +27,7 @@ class HomeController extends Controller {
     showAboutDialog(
       context: context!,
       applicationName: getEnv('APP_NAME'),
-      applicationIcon: Logo(),
+      applicationIcon: const Logo(),
       applicationVersion: nyloVersion,
     );
   }

--- a/lib/app/models/user.dart
+++ b/lib/app/models/user.dart
@@ -11,5 +11,6 @@ class User extends Model {
     email = data['email'];
   }
 
+  @override
   toJson() => {"name": name, "email": email};
 }

--- a/lib/app/networking/api_service.dart
+++ b/lib/app/networking/api_service.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:pretty_dio_logger/pretty_dio_logger.dart';
-import '/config/storage_keys.dart';
 import '/config/decoders.dart';
 import 'package:nylo_framework/nylo_framework.dart';
 
@@ -28,6 +27,7 @@ class ApiService extends NyApiService {
   String get baseUrl => getEnv('API_BASE_URL');
 
   @override
+  // ignore: overridden_fields
   final interceptors = {
     if (getEnv('APP_DEBUG') == true)
     PrettyDioLogger: PrettyDioLogger()

--- a/lib/app/networking/dio/interceptors/bearer_auth_interceptor.dart
+++ b/lib/app/networking/dio/interceptors/bearer_auth_interceptor.dart
@@ -5,10 +5,8 @@ class BearerAuthInterceptor extends Interceptor {
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
     String? userToken = Backpack.instance.read(StorageKey.userToken);
-    if (userToken != null) {
-      options.headers.addAll({"Authorization": "Bearer $userToken"});
-    }
-    return super.onRequest(options, handler);
+    options.headers.addAll({"Authorization": "Bearer $userToken"});
+      return super.onRequest(options, handler);
   }
 
   @override
@@ -17,7 +15,7 @@ class BearerAuthInterceptor extends Interceptor {
   }
 
   @override
-  void onError(DioException dioException, ErrorInterceptorHandler handler) {
-    handler.next(dioException);
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    handler.next(err);
   }
 }

--- a/lib/app/networking/dio/interceptors/example_interceptor.dart
+++ b/lib/app/networking/dio/interceptors/example_interceptor.dart
@@ -1,10 +1,6 @@
 import 'package:nylo_framework/nylo_framework.dart';
 
 class ExampleInterceptor extends Interceptor {
-  @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    return super.onRequest(options, handler);
-  }
 
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {
@@ -12,7 +8,7 @@ class ExampleInterceptor extends Interceptor {
   }
 
   @override
-  void onError(DioException dioException, ErrorInterceptorHandler handler) {
-    handler.next(dioException);
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    handler.next(err);
   }
 }

--- a/lib/bootstrap/app.dart
+++ b/lib/bootstrap/app.dart
@@ -29,7 +29,7 @@ class AppBuild extends StatelessWidget {
   Route<dynamic>? Function(RouteSettings settings) onGenerateRoute;
 
   AppBuild({
-    Key? key,
+    super.key,
     this.initialRoute,
     this.title,
     this.locale,
@@ -54,7 +54,7 @@ class AppBuild extends StatelessWidget {
     this.debugShowCheckedModeBanner = true,
     this.shortcuts,
     this.actions,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/config/design.dart
+++ b/lib/config/design.dart
@@ -30,7 +30,7 @@ final TextStyle appFont = GoogleFonts.montserrat();
 | Use the Logo() widget or Nylo.getAppLogo() display your logo
 | -------------------------------------------------------------------------- */
 
-Widget logo = Logo();
+Widget logo = const Logo();
 // File: resources/widgets/logo_widget.dart
 
 
@@ -40,7 +40,7 @@ Widget logo = Logo();
 | Use the Loader() widget or Nylo.getAppLoader() display your loader
 | -------------------------------------------------------------------------- */
 
-Widget loader = Loader();
+Widget loader = const Loader();
 // File: resources/widgets/loader_widget.dart
 
 
@@ -53,7 +53,7 @@ Widget loader = Loader();
 Widget getToastNotificationWidget({
   required ToastNotificationStyleType style,
   Function(ToastNotificationStyleMetaHelper helper)? toastNotificationStyleMeta, Function? onDismiss}) {
-  if (toastNotificationStyleMeta == null) return SizedBox.shrink();
+  if (toastNotificationStyleMeta == null) return const SizedBox.shrink();
 
   ToastMeta toastMeta = toastNotificationStyleMeta(NyToastNotificationStyleMetaHelper(style));
 

--- a/lib/config/localization.dart
+++ b/lib/config/localization.dart
@@ -19,19 +19,19 @@ final String languageCode = getEnv('DEFAULT_LOCALE', defaultValue: "en");
 | Define if you want the application to read the locale from the users
 | device settings or as you've defined in the [languageCode].
 |-------------------------------------------------------------------------- */
-final LocaleType localeType = LocaleType.asDefined; // device, asDefined
+const LocaleType localeType = LocaleType.asDefined; // device, asDefined
 
 /* languagesList
 | -------------------------------------------------------------------------
 | Add a list of supported languages.
 |-------------------------------------------------------------------------- */
-final List<String> languagesList = const ['en'];
+const List<String> languagesList = ['en'];
 
 /* assetsDirectory
 | -------------------------------------------------------------------------
 | Asset directory for your languages.
 |-------------------------------------------------------------------------- */
-final String assetsDirectory = 'lang/';
+const String assetsDirectory = 'lang/';
 
 /* valuesAsMap
 | -------------------------------------------------------------------------

--- a/lib/config/toast_notification_styles.dart
+++ b/lib/config/toast_notification_styles.dart
@@ -7,20 +7,24 @@ import 'package:nylo_framework/nylo_framework.dart';
 
 class NyToastNotificationStyleMetaHelper extends ToastNotificationStyleMetaHelper {
 
-  NyToastNotificationStyleMetaHelper(ToastNotificationStyleType? style) : super(style);
+  NyToastNotificationStyleMetaHelper(super.style);
 
+  @override
   onSuccess() {
     return ToastMeta.success();
   }
 
+  @override
   onWarning() {
     return ToastMeta.warning();
   }
 
+  @override
   onInfo() {
     return ToastMeta.info();
   }
 
+  @override
   onDanger() {
     return ToastMeta.danger();
   }

--- a/lib/config/validation_rules.dart
+++ b/lib/config/validation_rules.dart
@@ -1,4 +1,3 @@
-import 'package:nylo_framework/nylo_framework.dart';
 
 /* Validation Rules
 | -------------------------------------------------------------------------

--- a/lib/resources/pages/home_page.dart
+++ b/lib/resources/pages/home_page.dart
@@ -10,7 +10,7 @@ import '/app/controllers/home_controller.dart';
 class HomePage extends NyStatefulWidget<HomeController> {
   static const path = '/home';
 
-  HomePage() : super(path, child: _HomePageState());
+  HomePage({super.key}) : super(path, child: _HomePageState());
 }
 
 class _HomePageState extends NyState<HomePage> {
@@ -47,7 +47,7 @@ class _HomePageState extends NyState<HomePage> {
         actions: [
           IconButton(
             onPressed: widget.controller.showAbout,
-            icon: Icon(Icons.info_outline),
+            icon: const Icon(Icons.info_outline),
           ),
         ],
       ),
@@ -57,26 +57,26 @@ class _HomePageState extends NyState<HomePage> {
             crossAxisAlignment: CrossAxisAlignment.center,
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Logo(),
+              const Logo(),
               Text(
                 getEnv("APP_NAME"),
               ).displayMedium(context),
-              Text("Micro-framework for Flutter", textAlign: TextAlign.center)
+              const Text("Micro-framework for Flutter", textAlign: TextAlign.center)
                   .titleMedium(context)
                   .setColor(context, (color) => color.primaryAccent),
-              Text(
+              const Text(
                 "Build something amazing 💡",
               ).bodyMedium(context).alignCenter(),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: <Widget>[
-                  Divider(),
+                  const Divider(),
                   Container(
                     height: 250,
                     width: double.infinity,
-                    margin: EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
                     decoration: BoxDecoration(
                         color: ThemeColor.get(context).surfaceBackground,
                         borderRadius: BorderRadius.circular(8),
@@ -85,7 +85,7 @@ class _HomePageState extends NyState<HomePage> {
                             color: Colors.grey.withOpacity(0.1),
                             spreadRadius: 1,
                             blurRadius: 9,
-                            offset: Offset(0, 3),
+                            offset: const Offset(0, 3),
                           ),
                         ]),
                     child: Center(
@@ -95,38 +95,38 @@ class _HomePageState extends NyState<HomePage> {
                         children:
                         ListTile.divideTiles(context: context, tiles: [
                           MaterialButton(
+                            onPressed: widget.controller.onTapDocumentation,
                             child: Text(
                               "documentation".tr().capitalize(),
                             ).bodyLarge(context).setColor(
                                 context, (color) => color.surfaceContent),
-                            onPressed: widget.controller.onTapDocumentation,
                           ),
                           MaterialButton(
-                            child: Text(
+                            onPressed: widget.controller.onTapGithub,
+                            child: const Text(
                               "GitHub",
                             ).bodyLarge(context).setColor(
                                 context, (color) => color.surfaceContent),
-                            onPressed: widget.controller.onTapGithub,
                           ),
                           MaterialButton(
+                            onPressed: widget.controller.onTapChangeLog,
                             child: Text(
                               "changelog".tr().capitalize(),
                             ).bodyLarge(context).setColor(
                                 context, (color) => color.surfaceContent),
-                            onPressed: widget.controller.onTapChangeLog,
                           ),
                           MaterialButton(
+                            onPressed: widget.controller.onTapYouTube,
                             child: Text(
                               "YouTube Channel".tr().capitalize(),
                             ).bodyLarge(context).setColor(
                                 context, (color) => color.surfaceContent),
-                            onPressed: widget.controller.onTapYouTube,
                           ),
                         ]).toList(),
                       ),
                     ),
                   ),
-                  Text(
+                  const Text(
                     "Framework Version: $nyloVersion",
                   )
                       .bodyMedium(context)

--- a/lib/resources/themes/dark_theme.dart
+++ b/lib/resources/themes/dark_theme.dart
@@ -61,7 +61,7 @@ ThemeData darkTheme(ColorStyles color) {
 
 TextTheme _textTheme(ColorStyles colors) {
   Color primaryContent = colors.primaryContent;
-  TextTheme textTheme = TextTheme().apply(displayColor: primaryContent);
+  TextTheme textTheme = const TextTheme().apply(displayColor: primaryContent);
   return textTheme.copyWith(
       titleLarge: TextStyle(color: primaryContent.withOpacity(0.8)),
       labelLarge: TextStyle(color: primaryContent.withOpacity(0.8)),

--- a/lib/resources/themes/light_theme.dart
+++ b/lib/resources/themes/light_theme.dart
@@ -66,7 +66,7 @@ ThemeData lightTheme(ColorStyles color) {
 
 TextTheme _textTheme(ColorStyles colors) {
   Color primaryContent = colors.primaryContent;
-  TextTheme textTheme = TextTheme().apply(displayColor: primaryContent);
+  TextTheme textTheme = const TextTheme().apply(displayColor: primaryContent);
   return textTheme.copyWith(
       labelLarge: TextStyle(color: primaryContent.withOpacity(0.8)));
 }

--- a/lib/resources/themes/styles/color_styles.dart
+++ b/lib/resources/themes/styles/color_styles.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:nylo_framework/nylo_framework.dart';
 
 /// Interface for your base styles.
@@ -9,30 +8,44 @@ abstract class ColorStyles extends BaseColorStyles {
   /// * Available styles *
 
   // general
+  @override
   Color get background;
+  @override
   Color get primaryContent;
+  @override
   Color get primaryAccent;
 
+  @override
   Color get surfaceBackground;
+  @override
   Color get surfaceContent;
 
   // app bar
+  @override
   Color get appBarBackground;
+  @override
   Color get appBarPrimaryContent;
 
   // buttons
+  @override
   Color get buttonBackground;
+  @override
   Color get buttonPrimaryContent;
 
   // bottom tab bar
+  @override
   Color get bottomTabBarBackground;
 
   // bottom tab bar - icons
+  @override
   Color get bottomTabBarIconSelected;
+  @override
   Color get bottomTabBarIconUnselected;
 
   // bottom tab bar - label
+  @override
   Color get bottomTabBarLabelUnselected;
+  @override
   Color get bottomTabBarLabelSelected;
 
   // e.g. add a new style

--- a/lib/resources/themes/styles/dark_theme_colors.dart
+++ b/lib/resources/themes/styles/dark_theme_colors.dart
@@ -6,30 +6,44 @@ import '/resources/themes/styles/color_styles.dart';
 
 class DarkThemeColors implements ColorStyles {
   // general
+  @override
   Color get background => const Color(0xFF232c33);
 
+  @override
   Color get primaryContent => const Color(0xFFE1E1E1);
+  @override
   Color get primaryAccent => const Color(0xFF9999aa);
 
+  @override
   Color get surfaceBackground => Colors.white70;
+  @override
   Color get surfaceContent => Colors.black;
 
   // app bar
+  @override
   Color get appBarBackground => const Color(0xFF4b5e6d);
+  @override
   Color get appBarPrimaryContent => Colors.white;
 
   // buttons
+  @override
   Color get buttonBackground => Colors.white60;
+  @override
   Color get buttonPrimaryContent => const Color(0xFF232c33);
 
   // bottom tab bar
+  @override
   Color get bottomTabBarBackground => const Color(0xFF232c33);
 
   // bottom tab bar - icons
+  @override
   Color get bottomTabBarIconSelected => Colors.white70;
+  @override
   Color get bottomTabBarIconUnselected => Colors.white60;
 
   // bottom tab bar - label
+  @override
   Color get bottomTabBarLabelUnselected => Colors.white54;
+  @override
   Color get bottomTabBarLabelSelected => Colors.white;
 }

--- a/lib/resources/themes/styles/light_theme_colors.dart
+++ b/lib/resources/themes/styles/light_theme_colors.dart
@@ -6,30 +6,44 @@ import '/resources/themes/styles/color_styles.dart';
 
 class LightThemeColors implements ColorStyles {
   // general
+  @override
   Color get background => const Color(0xFFFFFFFF);
 
+  @override
   Color get primaryContent => const Color(0xFF000000);
+  @override
   Color get primaryAccent => const Color(0xFF0045a0);
 
+  @override
   Color get surfaceBackground => Colors.white;
+  @override
   Color get surfaceContent => Colors.black;
 
   // app bar
+  @override
   Color get appBarBackground => Colors.blue;
+  @override
   Color get appBarPrimaryContent => Colors.white;
 
   // buttons
+  @override
   Color get buttonBackground => Colors.blueAccent;
+  @override
   Color get buttonPrimaryContent => Colors.white;
 
   // bottom tab bar
+  @override
   Color get bottomTabBarBackground => Colors.white;
 
   // bottom tab bar - icons
+  @override
   Color get bottomTabBarIconSelected => Colors.blue;
+  @override
   Color get bottomTabBarIconUnselected => Colors.black54;
 
   // bottom tab bar - label
+  @override
   Color get bottomTabBarLabelUnselected => Colors.black45;
+  @override
   Color get bottomTabBarLabelSelected => Colors.black;
 }

--- a/lib/resources/widgets/loader_widget.dart
+++ b/lib/resources/widgets/loader_widget.dart
@@ -2,17 +2,17 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class Loader extends StatelessWidget {
-  const Loader({Key? key}) : super(key: key);
+  const Loader({super.key});
 
   @override
   Widget build(BuildContext context) {
     switch (Theme.of(context).platform) {
       case TargetPlatform.android:
-        return Center(child: CircularProgressIndicator());
+        return const Center(child: CircularProgressIndicator());
       case TargetPlatform.iOS:
-        return Center(child: CupertinoActivityIndicator());
+        return const Center(child: CupertinoActivityIndicator());
       default:
-        return Center(child: CircularProgressIndicator());
+        return const Center(child: CircularProgressIndicator());
     }
   }
 }

--- a/lib/resources/widgets/logo_widget.dart
+++ b/lib/resources/widgets/logo_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:nylo_framework/nylo_framework.dart';
 
 class Logo extends StatelessWidget {
-  const Logo({Key? key, this.height, this.width}) : super(key: key);
+  const Logo({super.key, this.height, this.width});
   final double? height;
   final double? width;
 

--- a/lib/resources/widgets/safearea_widget.dart
+++ b/lib/resources/widgets/safearea_widget.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 
 class SafeAreaWidget extends StatelessWidget {
   final Widget child;
-  const SafeAreaWidget({Key? key, required this.child}) : super(key: key);
+  const SafeAreaWidget({super.key, required this.child});
 
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      minimum: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      minimum: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: child,
     );
   }

--- a/lib/resources/widgets/toast_notification_widget.dart
+++ b/lib/resources/widgets/toast_notification_widget.dart
@@ -2,10 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:nylo_framework/nylo_framework.dart';
 
 class ToastNotification extends StatelessWidget {
-  const ToastNotification(ToastMeta toastMeta, {Function? onDismiss, Key? key})
+  const ToastNotification(ToastMeta toastMeta, {Function? onDismiss, super.key})
       : _toastMeta = toastMeta,
-        _dismiss = onDismiss,
-        super(key: key);
+        _dismiss = onDismiss;
 
   final Function? _dismiss;
   final ToastMeta _toastMeta;
@@ -13,9 +12,9 @@ class ToastNotification extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.symmetric(vertical: 12),
+      padding: const EdgeInsets.symmetric(vertical: 12),
       child: Container(
-        margin: EdgeInsets.symmetric(horizontal: 8.0),
+        margin: const EdgeInsets.symmetric(horizontal: 8.0),
         height: 100,
         decoration: BoxDecoration(
           color: context.isDarkMode ? "#282c34".toHexColor() : Colors.white,
@@ -25,7 +24,7 @@ class ToastNotification extends StatelessWidget {
               color: context.isDarkMode ? Colors.black12 : Colors.grey.withOpacity(0.1),
               spreadRadius: 3,
               blurRadius: 5,
-              offset: Offset(0, 2),
+              offset: const Offset(0, 2),
             ),
           ],
         ),
@@ -43,16 +42,16 @@ class ToastNotification extends StatelessWidget {
                 Container(
                   decoration: BoxDecoration(
                     color: _toastMeta.color,
-                    borderRadius: BorderRadius.only(bottomLeft: Radius.circular(8), topLeft: Radius.circular(8))
+                    borderRadius: const BorderRadius.only(bottomLeft: Radius.circular(8), topLeft: Radius.circular(8))
                   ),
                   alignment: Alignment.center,
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  margin: const EdgeInsets.only(right: 12),
                   child: Center(child: _toastMeta.icon),
-                  padding: EdgeInsets.symmetric(horizontal: 12),
-                  margin: EdgeInsets.only(right: 12),
                 ),
                 Expanded(
                   child: Container(
-                    margin: EdgeInsets.only(right: 40),
+                    margin: const EdgeInsets.only(right: 40),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisAlignment: MainAxisAlignment.center,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -198,6 +198,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.1"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      sha256: e2a421b7e59244faef694ba7b30562e489c2b489866e505074eb005cd7060db7
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -373,6 +381,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 
 dev_dependencies:
   flutter_launcher_icons: ^0.13.1
-#  lints: ^3.0.0
+  flutter_lints: ^3.0.1
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
This PR aims to enable the Flutter Linter in the base template. Currently, it's completely disabled in the `pubspec.yaml` and `analysis_options.yaml` files.

I've made the necessary modifications to include Flutter Linter configurations in these files, following the best practices recommended by the Flutter community.

I believe that enabling the Flutter Linter in the template will help maintain cleaner code and align with Flutter standards for all projects derived from this template.

Thank you for considering this proposal.